### PR TITLE
Allow the option to turn off the display of the Recent Posts dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ In your theme, you can call `pf_render( $name, $value, $options )` where you wan
 
 **Current options**
 * `show_numbers` - Whether to show a positional number next to each item. Makes it easy to see which position each item has. Default true.
+* `show_recent` - Whether to show the Recent Post select input. Default true.
 * `limit` - Limit how many items can be selected. Default 10.
+* `args` - Array of arguments passed to our `WP_Query` instances. Allows customizations of these queries, like setting a specific post type. See the [WordPress Developer Reference](https://developer.wordpress.org/reference/classes/wp_query/#methods-and-properties) for supported arguments.
 * `include_script` - Whether to include the init script for the input. Default true. If false, you'll have to include this yourself in order for it to work.
 ```
 jQuery( document ).ready( function( $ ) {

--- a/includes/classes/NS_Post_Finder.php
+++ b/includes/classes/NS_Post_Finder.php
@@ -219,6 +219,7 @@ class NS_Post_Finder {
 	public static function render( $name, $value, $options = array() ) {
 		$options = wp_parse_args( $options, array(
 			'show_numbers'   => true, // display # next to post
+			'show_recent'    => true, // display the Recent Post input
 			'limit'          => 10,
 			'include_script' => true, // Should the <script> tags to init post finder be included or not
 		) );
@@ -282,14 +283,24 @@ class NS_Post_Finder {
 			$args['post__not_in'] = $post_ids;
 		}
 
-		/**
-		 * Filters the recent post args.
-		 *
-		 * @since 0.1.0
-		 *
-		 * @param array $args Current args.
-		 */
-		$recent_posts = get_posts( apply_filters( 'post_finder_' . $name . '_recent_post_args', $args ) );
+		// Get recent posts, if that option is enabled
+		if ( $options['show_recent'] ) {
+			/**
+			 * Filters the recent post args.
+			 *
+			 * @since 0.1.0
+			 *
+			 * @param array $args Current args.
+			 */
+			$recent_posts_args = apply_filters( 'post_finder_' . $name . '_recent_post_args', $args );
+
+			$recent_posts = new WP_Query( $recent_posts_args );
+			$recent_posts = $recent_posts->have_posts() ? $recent_posts->posts : array();
+
+			wp_reset_postdata();
+		} else {
+			$recent_posts = '';
+		}
 
 		$class = 'post-finder';
 


### PR DESCRIPTION
Right now, the plugin adds a Recent Post select input, which is populated with recent items. I personally don't think this adds anything, but instead of just removing it, this PR adds the ability to hide it. By default it's left on, to keep functionality backwards compatible, but it's easy to turn off if you don't want it.

Also switch to using `WP_Query` instead of `get_posts` for that (which I missed in my other cleanup), and add more information to the README.