### PR TITLE
Only loading the plugin if on WordPress context

### DIFF
--- a/post-finder.php
+++ b/post-finder.php
@@ -6,6 +6,10 @@
  * Version: 0.3.0
  */
 
+ if ( ! defined( 'ABSPATH' ) ) {
+	return;
+}
+
 // Useful global constants
 define( 'POST_FINDER_VERSION', '0.3.0' );
 define( 'POST_FINDER_URL',     plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
Since we are including 'post-finder.php' in the autoload files config of composer, we need to ensure we only load the plugin if we are inside a WordPress context.

This fixes an issue I was having with our phpcs-composer tool where it was breaking phpcs because composer was loading the `post-finder.php` file and thus giving a fatal for undefined functions.