### PR TITLE
move saved connections above the search field

### DIFF
--- a/includes/classes/NS_Post_Finder.php
+++ b/includes/classes/NS_Post_Finder.php
@@ -360,18 +360,6 @@ class NS_Post_Finder {
 
 			<?php endif; ?>
 
-			<div class="search">
-				<h4>
-					<?php echo esc_html( $search_message ); ?>
-				</h4>
-				<input type="text" placeholder="<?php esc_attr_e( 'Enter a term or phrase', 'post-finder' ); ?>">
-				<button class="button"><?php esc_html_e( 'Search', 'post-finder' ); ?></button>
-				<div class="loader"></div>
-				<ul class="results"></ul>
-			</div><!-- ./search -->
-
-			<input type="hidden" name="<?php echo esc_attr( $name ); ?>" value="<?php echo esc_attr( $value ); ?>">
-
 			<ul class="list">
 				<?php
 				if ( ! empty( $posts ) ) {
@@ -405,6 +393,18 @@ class NS_Post_Finder {
 				}
 				?>
 			</ul>
+
+			<div class="search">
+				<h4>
+					<?php echo esc_html( $search_message ); ?>
+				</h4>
+				<input type="text" placeholder="<?php esc_attr_e( 'Enter a term or phrase', 'post-finder' ); ?>">
+				<button class="button"><?php esc_html_e( 'Search', 'post-finder' ); ?></button>
+				<div class="loader"></div>
+				<ul class="results"></ul>
+			</div><!-- ./search -->
+
+			<input type="hidden" name="<?php echo esc_attr( $name ); ?>" value="<?php echo esc_attr( $value ); ?>">
 		</div><!-- /.post-finder -->
 
 		<?php if ( $options['include_script'] ) : ?>


### PR DESCRIPTION
### Description of the Change

Based on a client's feedback, I've moved the selected posts section above the search field. Version 0.2.0 was setup this way, but in 0.3.0 having the selected posts below the search results pushes the already selected items off screen making if difficult to see what has already been added.

** Current Display**
![image](https://user-images.githubusercontent.com/6576646/81747542-443b2500-9476-11ea-800b-1c7399e5a900.png)

**Updated Display**
![image](https://user-images.githubusercontent.com/6576646/81747454-22da3900-9476-11ea-95d5-6e2c9e1063cd.png)

### Benefits

This will make it easier for editors to see what has already been attached to a post when adding new connections.

### Possible Drawbacks

None come to mind

### Verification Process
It's a visual update and I can't imagine a reason why we'd want the selected results at the bottom.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Changed - Moved selected posts listing above search results.